### PR TITLE
Added CURL configuration for longer post string

### DIFF
--- a/src/Silverpop/EngagePod.php
+++ b/src/Silverpop/EngagePod.php
@@ -726,6 +726,7 @@ class EngagePod {
         $ch = curl_init();
 
         //set the url, number of POST vars, POST data
+        curl_setopt($ch,CURLOPT_HTTPHEADER, array('Expect:'));
         curl_setopt($ch,CURLOPT_URL,$this->_getFullUrl());
         curl_setopt($ch,CURLOPT_POST,count($fields));
         curl_setopt($ch,CURLOPT_POSTFIELDS,$fields_string);


### PR DESCRIPTION
Added CURL configuration to accept longer post string...I was having problems with adding many fields it appeared CURL was the issue. Before adding 1024 characters seemed to be the ceiling.