### PR TITLE
Charset Curl - with non-english characters

### DIFF
--- a/src/Silverpop/EngagePod.php
+++ b/src/Silverpop/EngagePod.php
@@ -731,6 +731,8 @@ class EngagePod {
         curl_setopt($ch,CURLOPT_POST,count($fields));
         curl_setopt($ch,CURLOPT_POSTFIELDS,$fields_string);
         curl_setopt($ch,CURLOPT_RETURNTRANSFER,true);
+        curl_setopt($ch,CURLOPT_HTTPHEADER,array (
+   "Content-Type: application/x-www-form-urlencoded; charset=utf-8" ));
 
         //execute post
         $result = curl_exec($ch);


### PR DESCRIPTION
```
curl_setopt($ch,CURLOPT_HTTPHEADER,array (
+   "Content-Type: application/x-www-form-urlencoded; charset=utf-8" ));
```