### PR TITLE
CURLOPT_HTTPHEADER was being called twice so that the Expect:  was be…

### DIFF
--- a/src/Silverpop/EngagePod.php
+++ b/src/Silverpop/EngagePod.php
@@ -866,15 +866,17 @@ class EngagePod {
         $fields_string = http_build_query($fields);
         //open connection
         $ch = curl_init();
-
+        //set headers in array
+        $headers = array(
+         'Expect:',
+         'Content-Type: application/x-www-form-urlencoded; charset=utf-8',
+        );
         //set the url, number of POST vars, POST data
-        curl_setopt($ch,CURLOPT_HTTPHEADER, array('Expect:'));
+        curl_setopt($ch,CURLOPT_HTTPHEADER, $headers);
         curl_setopt($ch,CURLOPT_URL,$this->_getFullUrl());
         curl_setopt($ch,CURLOPT_POST,count($fields));
         curl_setopt($ch,CURLOPT_POSTFIELDS,$fields_string);
         curl_setopt($ch,CURLOPT_RETURNTRANSFER,true);
-        curl_setopt($ch,CURLOPT_HTTPHEADER,array (
-   "Content-Type: application/x-www-form-urlencoded; charset=utf-8" ));
 
         //execute post
         $result = curl_exec($ch);


### PR DESCRIPTION
CURLOPT_HTTPHEADER was being called twice so that the Expect:  was being overwritten and therefore breaking our longer curl calls.  I went ahead and created a headers array so that all the headers are included so they are not overwritten.  Now the Expect: works as it should as well as the rest of the headers.  The http headers should really be placed in array anyway so we add more headers if needed in the future.