### PR TITLE
Fixed typo that breaks getContact() when no RecipientID is available

### DIFF
--- a/src/Silverpop/EngagePod.php
+++ b/src/Silverpop/EngagePod.php
@@ -290,7 +290,7 @@ class EngagePod {
             "VALUE" => $columns[$key],
           );
         }
-        $data["Envelope"]["Body"]["SelectRecipeientData"]["COLUMN"] = $column_data;
+        $data["Envelope"]["Body"]["SelectRecipientData"]["COLUMN"] = $column_data;
       }
 
         $response = $this->_request($data);

--- a/src/Silverpop/EngagePod.php
+++ b/src/Silverpop/EngagePod.php
@@ -370,7 +370,7 @@ class EngagePod {
             $data["Envelope"]["Body"]["UpdateRecipient"]["COLUMN"][] = array("NAME" => $name, "VALUE" => $value);
         }
         foreach ($syncFields as $name => $value) {
-            $data["Envelope"]["Body"]["AddRecipient"]["SYNC_FIELDS"]["SYNC_FIELD"][] = array("NAME" => $name, "VALUE" => $value);
+            $data["Envelope"]["Body"]["UpdateRecipient"]["SYNC_FIELDS"]["SYNC_FIELD"][] = array("NAME" => $name, "VALUE" => $value);
         }
         $response = $this->_request($data);
         $result = $response["Envelope"]["Body"]["RESULT"];


### PR DESCRIPTION
Misspelling of "Recipient" caused the data envelope to be incorrectly formed in the EngagePod->getContact() method.