### PR TITLE
Branded domain change

### DIFF
--- a/src/Silverpop/EngagePod.php
+++ b/src/Silverpop/EngagePod.php
@@ -30,7 +30,7 @@ class EngagePod {
 
         // It would be a good thing to cache the jsessionid somewhere and reuse it across multiple requests
         // otherwise we are authenticating to the server once for every request
-        $this->_baseUrl = 'http://api' . $config['engage_server'] . '.silverpop.com/XMLAPI';
+        $this->_baseUrl = 'https://api-campaign-us-' . $config['engage_server'] . '.goacoustic.com';
         $this->_login($config['username'], $config['password']);
 
     }

--- a/src/Silverpop/EngagePod.php
+++ b/src/Silverpop/EngagePod.php
@@ -30,7 +30,7 @@ class EngagePod {
 
         // It would be a good thing to cache the jsessionid somewhere and reuse it across multiple requests
         // otherwise we are authenticating to the server once for every request
-        $this->_baseUrl = 'https://api-campaign-us-' . $config['engage_server'] . '.goacoustic.com';
+        $this->_baseUrl = 'https://api-campaign-us-' . $config['engage_server'] . '.goacoustic.com/XMLAPI';
         $this->_login($config['username'], $config['password']);
 
     }

--- a/src/Silverpop/Transact.php
+++ b/src/Silverpop/Transact.php
@@ -23,7 +23,7 @@ class Transact {
      * Sets $this->_baseUrl based on the engage server specified in config
      */
     public function __construct($engage_server) {
-        $this->_baseUrl = 'http://transact' . $engage_server . '.silverpop.com/XTMail';
+        $this->_baseUrl = 'https://transact' . $engage_server . '.goacoustic.com/XTMail';
     }
 
     /**


### PR DESCRIPTION
Engagepod URL's will be obsolete at the end of 2020. New urls updated with replacements from blog post https://help.goacoustic.com/hc/en-us/articles/360048880034-Standardized-Acoustic-URLs